### PR TITLE
V3 parsing

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -56,10 +56,10 @@ type NugetV3ResourceType =
 
 // Cache for nuget indices of sources
 type ResourceIndex = Map<NugetV3ResourceType,string>
-let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetV3Source,Task<ResourceIndex>>()
+let private nugetV3Resources = System.Collections.Concurrent.ConcurrentDictionary<NuGetSource,Task<ResourceIndex>>()
 let private rnd = Random()
 
-let getNuGetV3Resource (source : NuGetV3Source) (resourceType : NugetV3ResourceType) : Async<string> =
+let getNuGetV3Resource (source : NuGetSource) (resourceType : NugetV3ResourceType) : Async<string> =
     let key = source
     let getResourcesRaw () =
         async {
@@ -600,7 +600,7 @@ type PackageIndex =
       [<JsonProperty("count")>]
       Count : int }
 
-let private getPackageIndexRaw (source : NuGetV3Source) (packageName:PackageName) =
+let private getPackageIndexRaw (source : NuGetSource) (packageName:PackageName) =
     async {
         let! registrationUrl = getNuGetV3Resource source PackageIndex
         let url = registrationUrl.TrimEnd('/') + "/" + packageName.ToString().ToLowerInvariant() + "/index.json"
@@ -620,7 +620,7 @@ let private getPackageIndexMemoized =
 let getPackageIndex source packageName = getPackageIndexMemoized (source, packageName)
 
 
-let private getPackageIndexPageRaw (source:NuGetV3Source) (url:string) =
+let private getPackageIndexPageRaw (source: NuGetSource) (url:string) =
     async {
         let! rawData = safeGetFromUrl (source.Authentication, url, acceptJson)
         return
@@ -642,7 +642,7 @@ let private getPackageIndexPageMemoized =
 let getPackageIndexPage source (page:PackageIndexPage) = getPackageIndexPageMemoized (source, page.Id)
 
 
-let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerInfo) =
+let getRelevantPage (source:NuGetSource) (index:PackageIndex) (version:SemVerInfo) =
     async {
         try
             let normalizedVersion = SemVer.Parse (version.ToString().ToLowerInvariant())
@@ -703,7 +703,7 @@ let getRelevantPage (source:NuGetV3Source) (index:PackageIndex) (version:SemVerI
             return raise <| exn (sprintf "Failed to find relevant page in '%s'" index.Id, e)
     }
 
-let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let getPackageDetails (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     async {
         let! pageIndex = getPackageIndex source packageName
         match pageIndex with
@@ -770,7 +770,7 @@ let getPackageDetails (source:NuGetV3Source) (packageName:PackageName) (version:
     }
 
 /// Uses the NuGet v3 registration endpoint to retrieve package details .
-let GetPackageDetails (force:bool) (source:NuGetV3Source) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
+let GetPackageDetails (force:bool) (source:NuGetSource) (packageName:PackageName) (version:SemVerInfo) : Async<ODataSearchResult> =
     getDetailsFromCacheOr
         force
         source.Url

--- a/src/Paket.Core/Installation/RestoreProcess.fs
+++ b/src/Paket.Core/Installation/RestoreProcess.fs
@@ -103,7 +103,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
         let! result = async {
             let source =
                 match package.Source with
-                | NuGetV2 _ | NuGetV3 _ ->
+                | NuGet _ ->
                     let normalizeFeedUrl s = (normalizeFeedUrl s).Replace("https://","http://")
 
                     let normalized = normalizeFeedUrl package.Source.Url
@@ -111,8 +111,7 @@ let ExtractPackage(alternativeProjectRoot, root, groupName, sources, caches, for
                         sources
                         |> List.tryPick (fun source ->
                             match source with
-                            | NuGetV2 s when normalizeFeedUrl s.Url = normalized -> Some source
-                            | NuGetV3 s when normalizeFeedUrl s.Url = normalized -> Some source
+                            | NuGet s when normalizeFeedUrl s.Url = normalized -> Some source
                             | _ -> None)
 
                     match source with

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -114,7 +114,6 @@ module LockFileSerializer =
                   if not !hasReported then
                     yield "NUGET"
                     hasReported := true
-
                   yield "  remote: " + String.quoted source
                   match protocolVersion with
                   | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
@@ -293,9 +292,13 @@ module LockFileParser =
         | _, "GIT" -> RepositoryType "GIT"
         | _, "NUGET" -> RepositoryType "NUGET"
         | _, "GITHUB" -> RepositoryType "GITHUB"
-        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed -> Remote(ProtocolVersion(Some (trimmed.Trim())))
-        | _, String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (trimmed.Trim())))
-        | Some "NUGET", String.RemovePrefix "remote:" trimmed -> Remote(RemoteUrl(Some (PackageSource.Parse("source " + trimmed.Trim()).ToString())))
+        | Some "NUGET", String.RemovePrefix "protocolVersion:" trimmed ->
+                Remote(ProtocolVersion(Some (trimmed.Trim())))
+        | Some "NUGET", String.RemovePrefix "remote:" trimmed ->
+            let inner = PackageSource.Parse("source " + trimmed.Trim())
+            Remote(RemoteUrl(Some (inner.ToString())))
+        | _, String.RemovePrefix "remote:" trimmed ->
+            Remote(RemoteUrl(Some (trimmed.Trim())))
         | _, String.RemovePrefix "GROUP" trimmed -> Group(trimmed.Replace("GROUP","").Trim())
         | _, String.RemovePrefix "REFERENCES:" trimmed -> InstallOption(ReferencesMode(trimmed.Trim() = "STRICT"))
         | _, String.RemovePrefix "REDIRECTS:" trimmed ->

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -116,7 +116,9 @@ module LockFileSerializer =
                     hasReported := true
 
                   yield "  remote: " + String.quoted source
-                  yield "  protocolVersion: " + String.quoted (if protocolVersion = Some ProtocolVersion2 then "2" else "3")
+                  match protocolVersion with
+                  | Some p -> yield "  protocolVersion: " + String.quoted (if p = ProtocolVersion2 then "2" else "3")
+                  | None -> ()
 
                   for _,_,_,package in packages |> Seq.sortBy (fun (_,_,_,p) -> p.Name) do
                       let versionStr =

--- a/src/Paket.Core/PublicAPI.fs
+++ b/src/Paket.Core/PublicAPI.fs
@@ -646,7 +646,7 @@ type Dependencies(dependenciesFileName: string) =
         |> Seq.distinct
         |> Seq.map (fun source ->
             match source with
-            | NuGetV2 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion2 } as s) ->
                 let res = NuGetV3.getSearchAPI(s.Authentication,s.Url) |> Async.AwaitTask |> Async.RunSynchronously
                 match res with
                 | Some _ ->
@@ -655,7 +655,7 @@ type Dependencies(dependenciesFileName: string) =
                 | None ->
                     NuGetV2.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                     |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
-            | NuGetV3 s ->
+            | NuGet ({ ProtocolVersion = ProtocolVersion3 } as s) ->
                 NuGetV3.FindPackages(s.Authentication, s.Url, searchTerm, maxResults)
                 |> Async.map (FSharp.Core.Result.mapError (fun err -> s.Url, err))
             | LocalNuGet(s,_) ->

--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -108,7 +108,62 @@ let internal parseAuth(text:string, source) =
     else
         getAuth()
 
-let internal parseProtocolVersion(text:string, source) =
+let (|NugetV3Url|_|) (url: Uri) =
+  if url.ToString() = "https://api.nuget.org/v3/index.json" then Some () else None
+
+type 't ``[]`` with
+  member x.GetReverseIndex(i: int) = x.[x.Length - i]
+
+let (|Https|_|) (uri: Uri) = if uri.Scheme = "https" then Some () else None
+let (|Host|_|) (h: string) (uri: Uri) =
+    if uri.Host.EndsWith h
+    then Some ()
+    else None
+
+let (|LeadingPathSegments|_|) (segs: string[]) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount+1 then None // initial segment is a /, so we need to skip it
+    else
+        let items: string[] = uriSegs.[1..segCount]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|TrailingPathSegments|_|) (segs: string []) (uri: Uri) =
+    let segCount = segs.Length
+    let uriSegs = uri.Segments
+    if uriSegs.Length < segCount then None
+    else
+        let items: string[] = uriSegs.[(uriSegs.Length-segCount)..]
+        let matched =
+            (items, segs)
+            ||> Array.zip
+            |> Array.forall(fun (l, r) -> l.TrimEnd('/') = r) // have to trim end because the Uri.Segments api keeps the /-separators on the end of the segment
+        if matched then Some () else None
+
+let (|MyGetV3Url|_|) (url: Uri) =
+
+  // https://<your_myget_domain>/F/<your-feed-name>/<feed_endpoint>
+  try
+      match url with
+      | Https & Host "myget.org" & TrailingPathSegments [|"api";"v3"; "index.json"|] -> Some ()
+      | _ -> None
+  with _ -> None
+
+let (|ArtifactoryV3Url|_|) (url: Uri) =
+    match url with
+    | LeadingPathSegments [|"artifactory"; "api";"nuget";"v3"|] -> Some ()
+    | _ -> None
+
+let (|KnownNugetV3Endpoint|_|) url =
+    match Uri url with
+    | NugetV3Url | MyGetV3Url | ArtifactoryV3Url -> Some ()
+    | _ -> None
+
+let internal parseProtocolVersion(text:string, nugetSource) =
     if text.Contains("protocolVersion:") then
         if not (protocolVersionRegex.IsMatch(text)) then
             failwithf "Could not parse protocolVersion in \"%s\"" text
@@ -121,7 +176,13 @@ let internal parseProtocolVersion(text:string, source) =
         | (true, 3) -> Some ProtocolVersion3
         | _ -> failwithf "Unsupported protocolVersion in \"%s\". Should be either 2 or 3" text
     else
-        None
+        // derive protocolVersion from some well-known urls
+        try
+            match nugetSource with
+            | KnownNugetV3Endpoint -> Some ProtocolVersion3
+            | _ -> None
+        with
+        | _ -> None
 
 /// Represents the package source type.
 type PackageSource =
@@ -150,7 +211,7 @@ type PackageSource =
 
         PackageSource.Parse(feed, parseProtocolVersion(line, feed), parseAuth(line, feed))
 
-    static member Parse(source,auth) =
+    static member Parse(source, protocolVersion, auth) =
         match tryParseWindowsStyleNetworkPath source with
         | Some path -> PackageSource.Parse(path)
         | _ ->

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -11,7 +11,7 @@ open Paket.Requirements
 open Paket.ModuleResolver
 
 [<Test>]
-let ``should read empty config``() = 
+let ``should read empty config``() =
     let cfg = DependenciesFile.FromSource("")
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -23,12 +23,12 @@ source http://www.nuget.org/api/v2
 """
 
 [<Test>]
-let ``should read config which only contains a source``() = 
+let ``should read config which only contains a source``() =
     let cfg = DependenciesFile.FromSource(configWithSourceOnly)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
-    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head  |> shouldEqual (NuGetV2({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
+    cfg.Groups.[Constants.MainDependencyGroup].Sources.Head |> shouldEqual (NuGet({ Url = "http://www.nuget.org/api/v2"; ProtocolVersion = ProtocolVersion2; Authentication = AuthProvider.empty }))
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Auth.Retrieve true
         |> shouldEqual None
 let config1 = """
@@ -41,7 +41,7 @@ nuget "SignalR" "= 3.3.2"
 """
 
 [<Test>]
-let ``should read simple config``() = 
+let ``should read simple config``() =
     let cfg = DependenciesFile.FromSource(config1)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -57,7 +57,7 @@ nuget Castle.Windsor-log4net >= 3.2 prerelease # test
 """
 
 [<Test>]
-let ``should read simple config with prerelease and comment``() = 
+let ``should read simple config with prerelease and comment``() =
     let cfg = DependenciesFile.FromSource(configWithComment)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -72,7 +72,7 @@ nuget Castle.Windsor-log4net
 """
 
 [<Test>]
-let ``should read simple config with version line for bootstrapper``() = 
+let ``should read simple config with version line for bootstrapper``() =
     DependenciesFile.FromSource(configWithVersionLine) |> ignore
 
 
@@ -86,7 +86,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with additional comment``() = 
+let ``should read simple config with additional comment``() =
     let cfg = DependenciesFile.FromSource(config2)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FAKE"].Range |> shouldEqual (VersionRange.Between("3.0", "4.0"))
@@ -101,7 +101,7 @@ nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read simple config with comments``() = 
+let ``should read simple config with comments``() =
     let cfg = DependenciesFile.FromSource(config3)
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"].Range |> shouldEqual (VersionRange.Between("2.2", "3.0"))
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> List.head |> shouldEqual PackageSources.DefaultNuGetSource
@@ -111,13 +111,13 @@ let config4 = """
 source "https://www.nuget.org/api/v2" // first source
 source "http://nuget.org/api/v3"  // second
 
-nuget "FAKE" "~> 3.0" 
+nuget "FAKE" "~> 3.0"
 nuget "Rx-Main" "~> 2.2"
 nuget "MinPackage" "1.1.3"
 """
 
 [<Test>]
-let ``should read config with multiple sources``() = 
+let ``should read config with multiple sources``() =
     let cfg = DependenciesFile.FromSource(config4)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
@@ -145,7 +145,7 @@ let ``should read source file from config``() =
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
             Name = "src/app/FAKE/FileWithCommit.fs"
-            Version = VersionRestriction.Concrete "bla123zxc" 
+            Version = VersionRestriction.Concrete "bla123zxc"
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
@@ -168,7 +168,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read strict config``() = 
+let ``should read strict config``() =
     let cfg = DependenciesFile.FromSource(strictConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual true
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual None
@@ -183,7 +183,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with redirects``() = 
+let ``should read config with redirects``() =
     let cfg = DependenciesFile.FromSource(redirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.On)
@@ -198,7 +198,7 @@ nuget "FAKE" "~> 3.0"
 """
 
 [<Test>]
-let ``should read config with no redirects``() = 
+let ``should read config with no redirects``() =
     let cfg = DependenciesFile.FromSource(noRedirectsConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.Groups.[Constants.MainDependencyGroup].Options.Redirects |> shouldEqual (Some BindingRedirectsSettings.Off)
@@ -213,7 +213,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read content none config``() = 
+let ``should read content none config``() =
     let cfg = DependenciesFile.FromSource(noneContentConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -230,7 +230,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read config with specific framework``() = 
+let ``should read config with specific framework``() =
     let cfg = DependenciesFile.FromSource(specificFrameworkConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual None
@@ -249,7 +249,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no targets import config``() = 
+let ``should read no targets import config``() =
     let cfg = DependenciesFile.FromSource(noTargetsImportConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ImportTargets |> shouldEqual (Some false)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyLocal |> shouldEqual (Some false)
@@ -281,7 +281,7 @@ nuget "Microsoft.SqlServer.Types"
 """
 
 [<Test>]
-let ``should read no copy_content_to_output_dir config``() = 
+let ``should read no copy_content_to_output_dir config``() =
     let cfg = DependenciesFile.FromSource(copyContent)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.CopyContentToOutputDirectory |> shouldEqual (Some CopyToOutputDirectorySettings.Always)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.OmitContent |> shouldEqual None
@@ -298,7 +298,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes``() = 
+let ``should read config without quotes``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -317,7 +317,7 @@ nuget SignalR = 3.3.2
 """
 
 [<Test>]
-let ``should read config local quoted source``() = 
+let ``should read config local quoted source``() =
     let cfg = DependenciesFile.FromSource(configLocalQuotedSource)
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "D:\code\\temp with space"
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
@@ -338,7 +338,7 @@ nuget SignalR    = 3.3.2
 """
 
 [<Test>]
-let ``should read config without quotes but lots of whitespace``() = 
+let ``should read config without quotes but lots of whitespace``() =
     let cfg = DependenciesFile.FromSource(configWithoutQuotes)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).Count |> shouldEqual 4
@@ -352,7 +352,7 @@ let ``should read config without quotes but lots of whitespace``() =
 [<Test>]
 let ``should read github source file from config without quotes``() =
     let config = """github fsharp/FAKE:master   src/app/FAKE/Cli.fs
-                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs 
+                    github    fsharp/FAKE:bla123zxc src/app/FAKE/FileWithCommit.fs
                     github    fsharp/FAKE src/app/FAKE/FileWithCommit.fs github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -375,7 +375,7 @@ let ``should read github source file from config without quotes``() =
             Command = None
             OperatingSystemRestriction = None
             PackagePath = None
-            AuthKey = None } 
+            AuthKey = None }
           { Owner = "fsharp"
             Project = "FAKE"
             Origin = ModuleResolver.Origin.GitHubLink
@@ -389,7 +389,7 @@ let ``should read github source file from config without quotes``() =
 [<Test>]
 let ``should read github source file from config with quotes``() =
     let config = """github fsharp/FAKE:master  "src/app/FAKE/Cli.fs"
-                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs" 
+                    github fsharp/FAKE:bla123zxc "src/app/FAKE/FileWith Space.fs"
                     github fsharp/FAKE "src/app/FAKE/FileWith Space.fs" github
                  """
     let dependencies = DependenciesFile.FromSource(config)
@@ -562,7 +562,7 @@ let ``should read gist source file``() =
 
 nuget JetBrainsAnnotations.Fody
 
-gist misterx/5d9c6983004c1c9ec91f""" 
+gist misterx/5d9c6983004c1c9ec91f"""
     let dependencies = DependenciesFile.FromSource(config)
     dependencies.Groups.[Constants.MainDependencyGroup].RemoteFiles
     |> shouldEqual
@@ -688,7 +688,7 @@ nuget "FAKE"
 """
 
 [<Test>]
-let ``should read config without versions``() = 
+let ``should read config without versions``() =
     let cfg = DependenciesFile.FromSource(configWithoutVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "Rx-Main"] .Range|> shouldEqual (VersionRange.AtLeast "0")
@@ -702,12 +702,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source with no auth type specified``() = 
+let ``should read config with encapsulated password source with no auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordNoAuthType)
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -720,12 +720,12 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with encapsulated password source and auth type specified``() = 
+let ``should read config with encapsulated password source and auth type specified``() =
     let cfg = DependenciesFile.FromSource(configWithPasswordWithAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.ofUserPassword { Username = "tatü tata"; Password = "you got hacked!"; Type = NetUtils.AuthType.NTLM} } ]
@@ -736,7 +736,7 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with single-quoted password source``() = 
+let ``should read config with single-quoted password source``() =
     try
         DependenciesFile.FromSource configWithPasswordInSingleQuotes |> ignore
         failwith "Expected error"
@@ -749,14 +749,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable``() = 
+let ``should read config with password in env variable``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariable)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2;
             Authentication = AuthProvider.empty} ]
@@ -769,14 +769,14 @@ nuget Rx-Main
 """
 
 [<Test>]
-let ``should read config with password in env variable and auth type specified``() = 
+let ``should read config with password in env variable and auth type specified``() =
     Environment.SetEnvironmentVariable("FEED_USERNAME", "user XYZ", EnvironmentVariableTarget.Process)
     Environment.SetEnvironmentVariable("FEED_PASSWORD", "pw Love", EnvironmentVariableTarget.Process)
     let cfg = DependenciesFile.FromSource( configWithPasswordInEnvVariableAndAuthType)
-    
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
-    |> shouldEqual [ 
-        PackageSource.NuGetV2 { 
+
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
+    |> shouldEqual [
+        PackageSource.NuGet {
             Url = "http://www.nuget.org/api/v2"
             ProtocolVersion = ProtocolVersion2
             Authentication = AuthProvider.empty } ]
@@ -786,12 +786,12 @@ let ``should read config with password in env variable and auth type specified``
 let configWithExplicitVersions = """
 source "http://www.nuget.org/api/v2"
 
-nuget FSharp.Compiler.Service == 0.0.62 
+nuget FSharp.Compiler.Service == 0.0.62
 nuget FsReveal == 0.0.5-beta
 """
 
 [<Test>]
-let ``should read config explicit versions``() = 
+let ``should read config explicit versions``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitVersions)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.OverrideAll (SemVer.Parse "0.0.62"))
@@ -804,7 +804,7 @@ nuget Nancy.Owin 0.22.2
 """
 
 [<Test>]
-let ``should read config with local source``() = 
+let ``should read config with local source``() =
     let cfg = DependenciesFile.FromSource(configWithLocalSource)
 
     let p = cfg.Groups.[Constants.MainDependencyGroup].Packages |> List.find (fun x-> x.Name = PackageName "Nancy.Owin")
@@ -813,7 +813,7 @@ let ``should read config with local source``() =
 
 
 [<Test>]
-let ``should read config with package name containing nuget``() = 
+let ``should read config with package name containing nuget``() =
     let config = """
     nuget nuget.Core 0.1
     """
@@ -822,7 +822,7 @@ let ``should read config with package name containing nuget``() =
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "nuget.Core"].Range |> shouldEqual (VersionRange.Specific (SemVer.Parse "0.1"))
 
 [<Test>]
-let ``should read config with single framework restriction``() = 
+let ``should read config with single framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 framework: >= net40
     """
@@ -835,7 +835,7 @@ let ``should read config with single framework restriction``() =
 
 
 [<Test>]
-let ``should read config with framework restriction``() = 
+let ``should read config with framework restriction``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta framework: net35, >= net40
     """
@@ -849,7 +849,7 @@ let ``should read config with framework restriction``() =
     p.Settings.SpecificVersion |> shouldEqual None
 
 [<Test>]
-let ``should read config with no targets import``() = 
+let ``should read config with no targets import``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta import_targets: false, copy_local: false, specific_version: false
     """
@@ -864,7 +864,7 @@ let ``should read config with no targets import``() =
     p.Settings.OmitContent |> shouldEqual None
 
 [<Test>]
-let ``should read config with content none``() = 
+let ``should read config with content none``() =
     let config = """
     nuget Foobar 1.2.3 alpha beta content: none, copy_local: false, specific_version: true
     """
@@ -879,7 +879,7 @@ let ``should read config with content none``() =
     p.Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
 
 [<Test>]
-let ``should read config with  !~> 3.3``() = 
+let ``should read config with  !~> 3.3``() =
     let config = """source https://www.nuget.org/api/v2
 
 nuget AutoMapper ~> 3.2
@@ -903,11 +903,11 @@ nuget Caliburn.Micro !~> 2.0.2
 
 
 let configWithInvalidPrereleaseString = """
-    nuget Plossum.CommandLine !0.3.0.14   
+    nuget Plossum.CommandLine !0.3.0.14
 """
 
 [<Test>]
-let ``should report error on invalid prerelease string``() = 
+let ``should report error on invalid prerelease string``() =
     try
         DependenciesFile.FromSource(configWithInvalidPrereleaseString) |> ignore
         failwith "error"
@@ -919,7 +919,7 @@ let html = """
 """
 
 [<Test>]
-let ``should not read hhtml``() = 
+let ``should not read hhtml``() =
     try
         DependenciesFile.FromSource(html) |> ignore
         failwith "error"
@@ -939,7 +939,7 @@ nuget NUnit
 """
 
 [<Test>]
-let ``should read config with additional group``() = 
+let ``should read config with additional group``() =
     let cfg = DependenciesFile.FromSource(configWithAdditionalGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -961,7 +961,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with nested group``() = 
+let ``should read config with nested group``() =
     let cfg = DependenciesFile.FromSource(configWithNestedGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -986,7 +986,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with explizit main group``() = 
+let ``should read config with explizit main group``() =
     let cfg = DependenciesFile.FromSource(configWithExplicitMainGroup)
 
     cfg.GetDependenciesInGroup(Constants.MainDependencyGroup).[PackageName "FSharp.Compiler.Service"].Range |> shouldEqual (VersionRange.Minimum (SemVer.Parse "0"))
@@ -1011,7 +1011,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with reference condition``() = 
+let ``should read config with reference condition``() =
     let cfg = DependenciesFile.FromSource(configWithReferenceCondition)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.ReferenceCondition |> shouldEqual (Some "MAIN-GROUP")
@@ -1029,7 +1029,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet v3 feed``() = 
+let ``should read config with NuGet v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3Source)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual Constants.DefaultNuGetV3Stream
@@ -1041,7 +1041,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with NuGet http v3 feed``() = 
+let ``should read config with NuGet http v3 feed``() =
     let cfg = DependenciesFile.FromSource(configWithNugetV3HTTPSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual (Constants.DefaultNuGetV3Stream.Replace("https://","http://"))
@@ -1054,7 +1054,7 @@ nuget Paket.Core
 """
 
 [<Test>]
-let ``should read config with duplicate NuGet source``() = 
+let ``should read config with duplicate NuGet source``() =
     let cfg = DependenciesFile.FromSource(configWithDuplicateSource)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Length |> shouldEqual 1
@@ -1069,7 +1069,7 @@ nuget Oracle.ManagedDataAccess framework: >= net40 content: none
 """
 
 [<Test>]
-let ``should not read config with invalid settings``() = 
+let ``should not read config with invalid settings``() =
     shouldFail (fun () -> DependenciesFile.FromSource(configWithInvalidInstallSettings) |> ignore)
 
 let strategyConfig = sprintf """
@@ -1084,13 +1084,13 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and max strategy``() = 
+let ``should read config with min and max strategy``() =
     let cfg = DependenciesFile.FromSource(strategyConfig "min" "max")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Max)
 
     cfg.Groups.[Constants.MainDependencyGroup].Sources |> shouldEqual [PackageSource.NuGetV2Source "http://www.nuget.org/api/v2"]
-    
+
 let noStrategyConfig = sprintf """
 strategy %s
 source "http://www.nuget.org/api/v2" // first source
@@ -1102,7 +1102,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with min and no strategy``() = 
+let ``should read config with min and no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig "min")
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1119,7 +1119,7 @@ group Test
 """
 
 [<Test>]
-let ``should read config with no strategy``() = 
+let ``should read config with no strategy``() =
     let cfg = DependenciesFile.FromSource(noStrategyConfig')
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual None
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual None
@@ -1152,7 +1152,7 @@ group Build
 """
 
 [<Test>]
-let ``should read config with combined strategy``() = 
+let ``should read config with combined strategy``() =
     let cfg = DependenciesFile.FromSource(combinedStrategyConfig)
     cfg.Groups.[Constants.MainDependencyGroup].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
     cfg.Groups.[GroupName "Test"].Options.ResolverStrategyForTransitives |> shouldEqual (Some ResolverStrategy.Min)
@@ -1169,7 +1169,7 @@ nuget FsReveal
 """
 
 [<Test>]
-let ``should read config with very similar feeds``() = 
+let ``should read config with very similar feeds``() =
     let cfg = DependenciesFile.FromSource(configWithVerySimilarFeeds)
 
     try
@@ -1177,12 +1177,12 @@ let ``should read config with very similar feeds``() =
     with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
-    
+
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Head.Url |> shouldEqual "http://nexus1:8081/nexus/service/local/nuget/nuget-repo"
 
     try
         cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Auth.Retrieve false |> shouldNotEqual None
-    with e -> 
+    with e ->
         System.Console.Error.WriteLine("Credential Provider failed: " + e.Message)
         () // Might throw when we have a global authentication provider
     cfg.Groups.[Constants.MainDependencyGroup].Sources.Tail.Head.Url |> shouldEqual "http://nexus2:8081/nexus/service/local/nuget/nuget-repo"
@@ -1195,7 +1195,7 @@ nuget System.Data.SQLite 1.0.98.1 content: none
 """
 
 [<Test>]
-let ``should read config with target framework``() = 
+let ``should read config with target framework``() =
     let cfg = DependenciesFile.FromSource(configTargetFramework)
 
     cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
@@ -1251,7 +1251,7 @@ let ``should throw on config with invalid target framework`` config =
     shouldFail<Exception> (fun () -> DependenciesFile.FromSource(config) |> ignore)
 
 [<Test>]
-let ``should read packages with redirects``() = 
+let ``should read packages with redirects``() =
     let config = """
 redirects on
 source http://www.nuget.org/api/v2
@@ -1293,7 +1293,7 @@ git http://github.com/fsprojects/Chessie.git master
 """
 
 [<Test>]
-let ``should read paket git config``() = 
+let ``should read paket git config``() =
     let cfg = DependenciesFile.FromSource(paketGitConfig)
     let gitSource = cfg.Groups.[Constants.MainDependencyGroup].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "git@github.com:fsprojects/Paket.git"
@@ -1341,7 +1341,7 @@ group Dev
 """
 
 [<Test>]
-let ``should read paket git config with build command``() = 
+let ``should read paket git config with build command``() =
     let cfg = DependenciesFile.FromSource(paketGitConfigWithBuildCommand)
     let gitSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
@@ -1382,7 +1382,7 @@ let ``should read paket git config with build command``() =
     let nupkgtestSource = cfg.Groups.[GroupName "Dev"].Sources.Head
     nupkgtestSource.Url |> shouldEqual "paket-files/dev/github.com/forki/nupkgtest/source"
 
-    
+
     let buildSource = cfg.Groups.[GroupName "Dev"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     buildSource.GetCloneUrl() |> shouldEqual "https://github.com/forki/nupkgtest.git"
     buildSource.Owner |> shouldEqual "github.com/forki"
@@ -1391,7 +1391,7 @@ let ``should read paket git config with build command``() =
     buildSource.PackagePath |> shouldEqual (Some "/source/")
     buildSource.Command |> shouldEqual (Some "build.cmd")
     buildSource.OperatingSystemRestriction |> shouldEqual None
- 
+
     cfg.Groups.[GroupName "Dev"].Sources
     |> List.map (fun x -> x.Url)
     |> shouldContain "paket-files/dev/github.com/forki/nupkgtest/source"
@@ -1411,9 +1411,9 @@ group Git
 """
 
 [<Test>]
-let ``should read paket git config with tags``() = 
+let ``should read paket git config with tags``() =
     let cfg = DependenciesFile.FromSource(paketGitTagsConfig)
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1440,7 +1440,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1449,7 +1449,7 @@ let ``should read paket git config with tags``() =
     gitSource.OperatingSystemRestriction |> shouldEqual None
     gitSource.PackagePath |> shouldEqual (Some "/temp/")
     gitSource.Project |> shouldEqual "Paket"
-    
+
     let gitSource = cfg.Groups.[GroupName "git"].RemoteFiles.Tail.Tail.Tail.Tail.Head
     gitSource.GetCloneUrl() |> shouldEqual "https://github.com/fsprojects/Paket.git"
     gitSource.Owner |> shouldEqual "github.com/fsprojects"
@@ -1472,7 +1472,7 @@ nuget Chessie
 """
 
 [<Test>]
-let ``should read config with caches``() = 
+let ``should read config with caches``() =
     let cfg = DependenciesFile.FromSource(simpleCacheConfig)
     let main = cfg.Groups.[Constants.MainDependencyGroup]
     main.Caches |> List.length |> shouldEqual 2
@@ -1489,7 +1489,7 @@ let ``should read config with caches``() =
 let ``async cache should work``() =
      // this test is already include in the to Visualfsharp repo
      let x = ref 0
-     let someSlowFunc mykey = async { 
+     let someSlowFunc mykey = async {
          Console.WriteLine "Simulated downloading..."
          do! Async.Sleep 400
          Console.WriteLine "Simulated downloading Done."
@@ -1500,7 +1500,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
          do! memFunc "a" |> Async.Ignore
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
@@ -1510,7 +1510,7 @@ let ``async cache should work``() =
          do! memFunc "a" |> Async.Ignore
          for i = 1 to 30 do
              Async.Start( memFunc "a" |> Async.Ignore )
-         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a")) 
+         do! [|1 .. 30|] |> Seq.map(fun _ -> (memFunc "a"))
              |> Async.Parallel |> Async.Ignore
      } |> Async.RunSynchronously
      !x |> shouldEqual 1
@@ -1534,9 +1534,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from main group``() = 
+let ``should read autodetect from main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfig)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 let autodetectconfigSpecific = """
@@ -1560,9 +1560,9 @@ nuget xunit
 """
 
 [<Test>]
-let ``should read autodetect from specific main group``() = 
+let ``should read autodetect from specific main group``() =
     let cfg = DependenciesFile.FromSource(autodetectconfigSpecific)
-    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions 
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
     |> shouldEqual FrameworkRestrictions.AutoDetectFramework
 
 [<Test>]
@@ -1576,7 +1576,7 @@ let ``parsing generate load scripts`` () =
     ]
     let results = [
         for case, expectation in casesAndExpectation do
-            let config = 
+            let config =
                 DependenciesFile.FromSource <|
                 match case with
                 | Some value ->
@@ -1606,11 +1606,11 @@ nuget FAKE
 """
 
 [<Test>]
-let ``should read config with cli tool``() = 
+let ``should read config with cli tool``() =
     let cfg = DependenciesFile.FromSource(configWithCLitTool)
     cfg.Groups.[Constants.MainDependencyGroup].Options.Strict |> shouldEqual false
 
-    cfg.Groups.[Constants.MainDependencyGroup].Sources 
+    cfg.Groups.[Constants.MainDependencyGroup].Sources
     |> shouldEqual [PackageSources.DefaultNuGetSource]
 
     let tool = cfg.Groups.[Constants.MainDependencyGroup].Packages.Head

--- a/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorSpecs.fs
@@ -88,7 +88,6 @@ nuget "Rx-Main" "~> 2.0" framework: >= net40 """
 let ``should generate lock file with no targets import for packages``() =
     let expected = """NUGET
   remote: "D:\code\temp with space"
-  protocolVersion: 2
     Castle.Windsor (2.1) - import_targets: false, restriction: == net35
     Castle.Windsor-log4net (3.3) - import_targets: false, restriction: == net35
       Castle.Windsor (>= 2.0)

--- a/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/GeneratorWithMutlipleSourcesSpecs.fs
@@ -31,6 +31,7 @@ let graph =
 
 let expected = """NUGET
   remote: http://www.nuget.org/api/v2
+  protocolVersion: 2
     Castle.Windsor (2.1)
     Castle.Windsor-log4net (3.3)
       Castle.Windsor (>= 2.0)
@@ -43,7 +44,7 @@ let expected = """NUGET
       Rx-Core (>= 2.1)"""
 
 [<Test>]
-let ``should generate lock file``() = 
+let ``should generate lock file``() =
     let cfg = DependenciesFile.FromSource(config1)
     ResolveWithGraph(cfg,noSha1,VersionsFromGraphAsSeq graph, PackageDetailsFromGraph graph).[Constants.MainDependencyGroup].ResolvedPackages.GetModelOrFail()
     |> LockFileSerializer.serializePackages cfg.Groups.[Constants.MainDependencyGroup].Options


### PR DESCRIPTION
more WIP on the fixes to get the tests green

outstanding test failures now fall into one of these cases:
* [x] automatically classifying certain well-known urls as v2 or v3 (ie the nuget v3 API should be protocol 3, etc)
* [x] local-file nuget sources have a protocol written (which is not necessary)
* [x] local-file nuget sources have extra quotes around their paths